### PR TITLE
Add background agent commands, --bg flag, and new slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,15 @@ Quick reference for the most common ones:
 | `/review` | `/review` | ✅ |
 | `/tasks` | `/tasks` | ✅ |
 | `/agents` | `/agent` | ⚠️ Renamed |
+| `/background` (`/bg`) | — | ❌ Claude Code-only (detach to background agent; closest: Ctrl+X then b) |
 | `/btw` | `/ask` (experimental) | ⚠️ Renamed — side question without adding to history |
 | `/cost` | `/usage` | ⚠️ Renamed |
 | `/export` | `/share` (`/export`) | ⚠️ Renamed — `/export` now also a Copilot alias |
+| `/goal` | — | ❌ Claude Code-only (set goal for multi-turn agentic loop) |
 | `/remote-control` | `/remote [on\|off]` | ⚠️ Renamed — no args shows status; `on`/`off` toggles |
 | `/memory` | — | ❌ Not available |
+| `/scroll-speed` | — | ❌ Claude Code-only (interactive scroll speed adjustment) |
+| `/stop` | — | ❌ Claude Code-only (stop current background session) |
 | `/autofix-pr` | — | ❌ Not available |
 | `/web-setup` | — | ❌ Not available |
 | `/team-onboarding` | — | ❌ Not available |
@@ -196,6 +200,15 @@ The setup script symlinks these directories so both tools share the same files:
 - **Plugin URL loading** (`--plugin-url`) is a Claude Code-only feature — Copilot CLI only supports local plugins via `copilot plugin install <dir>`
 - **`/team-onboarding`** is a Claude Code–only command (generates team onboarding guides from session history) — no Copilot CLI equivalent
 - **`/loop`** (`/proactive`) is a Claude Code–only command (runs a prompt repeatedly while the session stays open) — no Copilot CLI equivalent
+- **`--bg`** flag (start session as a background agent) is Claude Code-only — closest: Ctrl+X then b to promote a running task to the background
+- **Background agent session management** (`attach`, `logs`, `respawn`, `rm`, `stop` subcommands) is Claude Code-only — Copilot CLI manages sessions via `/session` and `--resume`
+- **`/background`** (`/bg`) slash command (detach current session to background) is Claude Code-only — closest: Ctrl+X then b
+- **`/goal [condition|clear]`** is a Claude Code-only command (set a goal for multi-turn agentic loop) — no Copilot CLI equivalent
+- **`/stop`** slash command (stop current background session while attached) is Claude Code-only — no Copilot CLI equivalent
+- **`/scroll-speed`** is a Claude Code-only UI command — no Copilot CLI equivalent
+- **`claude install [version]`** is Claude Code-only — use `copilot update` (no version pinning)
+- **`claude setup-token`** is Claude Code-only — use `gh auth token` for CI/script authentication
+- **`claude project purge [path]`** is Claude Code-only — use `/session cleanup` or `/session prune` in Copilot CLI
 - **`/tui`**, **`/focus`**, **`/heapdump`**, **`/recap`** are Claude Code–only UI/debugging commands — no Copilot CLI equivalents
 - **`/ultrareview [PR]`** is a Claude Code–only command (deep cloud-based code review) — use `/review` in Copilot CLI for local reviews
 - **`/keep-alive [on|off|busy|DURATION]`** (`/caffeinate`) is a Copilot CLI-only slash command (prevent machine sleep; duration accepts bare numbers, `30m`, `2h`, `1d`) — no Claude Code equivalent

--- a/cpc
+++ b/cpc
@@ -130,6 +130,9 @@ SUBCOMMANDS = {
     "update", "init", "plugin", "auth", "agents", "mcp",
     "remote-control", "auto-mode", "autofix-pr", "web-setup",
     "team-onboarding", "loop", "proactive",
+    # Background agent session management (new in Claude Code)
+    "attach", "logs", "respawn", "rm", "stop",
+    "ultrareview", "project", "setup-token", "install",
 }
 
 
@@ -178,6 +181,41 @@ def handle_subcommand(subcmd, rest_args):
     if subcmd in ("loop", "proactive"):
         warn("Not available in Copilot CLI. /loop (/proactive) runs a prompt repeatedly while the session stays open")
         return None
+    # --- Background agent session management ---
+    if subcmd == "attach":
+        warn("Not available in Copilot CLI. Background agent session management is Claude Code-only. "
+             "Closest: resume a session with 'copilot --resume'")
+        return None
+    if subcmd == "logs":
+        warn("Not available in Copilot CLI. Background agent session management is Claude Code-only")
+        return None
+    if subcmd == "respawn":
+        warn("Not available in Copilot CLI. Background agent session management is Claude Code-only. "
+             "Closest: resume a session with 'copilot --resume'")
+        return None
+    if subcmd == "rm":
+        warn("Not available in Copilot CLI. Background agent session management is Claude Code-only. "
+             "Use /session delete <ID> inside a Copilot CLI session to remove sessions")
+        return None
+    if subcmd == "stop":
+        warn("Not available in Copilot CLI. Background agent session management is Claude Code-only")
+        return None
+    if subcmd == "ultrareview":
+        warn("Not available in Copilot CLI. Use /review inside a Copilot CLI session for local reviews")
+        return None
+    if subcmd == "project":
+        sub = rest_args[0] if rest_args else None
+        if sub == "purge":
+            warn("Not available in Copilot CLI. Use /session cleanup or /session prune inside a session")
+            return None
+        warn(f"Unknown 'project' subcommand '{sub}'")
+        return None
+    if subcmd == "setup-token":
+        warn("Not available in Copilot CLI. Use 'gh auth token' for CI/script authentication with GitHub")
+        return None
+    if subcmd == "install":
+        warn("Not available in Copilot CLI. Use 'copilot update' to update, or reinstall via your package manager")
+        return None
     return None
 
 
@@ -186,6 +224,7 @@ def handle_subcommand(subcmd, rest_args):
 # ---------------------------------------------------------------------------
 
 WARN_FLAGS = {
+    "--bg":                             (0, "Not available in Copilot CLI. Background agent mode is Claude Code-only. Closest: Ctrl+X then b to promote to background"),
     "--system-prompt":              (1, "Use .github/copilot-instructions.md or .instructions.md files instead"),
     "--system-prompt-file":         (1, "Use .github/copilot-instructions.md or .instructions.md files instead"),
     "--append-system-prompt":       (1, "Use .github/copilot-instructions.md or .instructions.md files instead"),
@@ -497,6 +536,21 @@ Translated flags:
   --no-remote                          → --no-remote (disable remote access)
   --teleport                           → --resume (cloud session picker)
   --name / -n NAME                     → --name=NAME (session name)
+
+Unsupported flags:
+  --bg                                 Not available (background agent mode is Claude Code-only;
+                                       closest: Ctrl+X then b to promote to background)
+
+Background agent subcommands (Claude Code-only, no Copilot equivalent):
+  cpc attach <id>                      Not available (use --resume to reconnect)
+  cpc logs <id>                        Not available
+  cpc respawn <id>                     Not available (use --resume)
+  cpc rm <id>                          Not available (use /session delete)
+  cpc stop <id>                        Not available
+  cpc install [version]                Not available (use copilot update)
+  cpc setup-token                      Not available (use gh auth token)
+  cpc project purge [path]             Not available (use /session cleanup)
+  cpc ultrareview [target]             Not available (use /review)
 
 Passthrough flags (same in both CLIs):
   --model, --add-dir, --agent, --output-format, -p, -c, -v, --resume, etc.

--- a/skills/claude-compat/SKILL.md
+++ b/skills/claude-compat/SKILL.md
@@ -24,11 +24,20 @@ Use this reference when you know a Claude Code command and want the Copilot CLI 
 | `claude auth logout` | `/logout` (interactive) | ⚠️ `copilot logout` subcommand removed; use `/logout` in-session |
 | `claude auth status` | `copilot version` | ⚠️ Partial |
 | `claude plugin ...` | `copilot plugin ...` | ✅ Same |
-| `claude agents` | `/agent` (interactive) | ⚠️ Interactive only |
+| `claude agents` | `/agent` (interactive) | ⚠️ Interactive only — Claude Code now opens an agent view to monitor/dispatch parallel background sessions |
 | `claude mcp` | `copilot mcp` | ✅ Same |
 | `claude auto-mode defaults` | — | ❌ Not available |
 | `claude auto-mode config` | — | ❌ Not available |
 | `claude remote-control` | `--remote` or `/remote` (interactive) | ⚠️ Mapped |
+| `claude attach <id>` | — | ❌ Not available (background agent session management; closest: `copilot --resume`) |
+| `claude logs <id>` | — | ❌ Not available (background agent session management) |
+| `claude respawn <id>` | — | ❌ Not available (background agent session management; closest: `copilot --resume`) |
+| `claude rm <id>` | — | ❌ Not available (use `/session delete <ID>` in Copilot CLI) |
+| `claude stop <id>` | — | ❌ Not available (background agent session management) |
+| `claude ultrareview [target]` | `/review` (interactive) | ⚠️ Partial (cloud-based deep review; `/review` is local only) |
+| `claude project purge [path]` | — | ❌ Not available (use `/session cleanup` or `/session prune`) |
+| `claude setup-token` | — | ❌ Not available (use `gh auth token` for CI/scripts) |
+| `claude install [version]` | `copilot update` | ⚠️ Partial (no version pinning; update only) |
 | — | `copilot completion SHELL` | ℹ️ Copilot-only (print shell completion script for bash/zsh/fish) |
 
 ## CLI Flag Mapping
@@ -84,6 +93,7 @@ Use this reference when you know a Claude Code command and want the Copilot CLI 
 | `--plugin-url` | Not available (URL-based plugin loading is Claude Code-only; use `copilot plugin install <dir>` for local plugins) |
 | `--tmux` | Not available |
 | `--remote-control-session-name-prefix` | Not available (Remote Control is not supported) |
+| `--bg` | Not available (starts session as background agent; closest: Ctrl+X then b to promote to background) |
 
 ### Copilot CLI Only (no Claude Code equivalent)
 | Copilot CLI | Notes |
@@ -115,10 +125,10 @@ Use this reference when you know a Claude Code command and want the Copilot CLI 
 | `/ultrareview [PR]` | `/review [PROMPT]` | Cloud-based deep review; `/review` in Claude Code is the local equivalent |
 
 ### Claude Code Only (no Copilot equivalent)
-`/autofix-pr`, `/chrome`, `/color`, `/config`, `/copy`, `/desktop`, `/doctor`,
-`/effort`, `/fast`, `/fewer-permission-prompts`, `/focus`, `/heapdump`, `/hooks`, `/loop` (`/proactive`), `/memory`, `/recap`,
-`/sandbox`, `/schedule` (`/routines`), `/security-review`, `/setup-bedrock`,
-`/stats`, `/team-onboarding`, `/tui`, `/voice`, `/web-setup`
+`/autofix-pr`, `/background` (`/bg`), `/chrome`, `/color`, `/config`, `/copy`, `/desktop`, `/doctor`,
+`/effort`, `/fast`, `/fewer-permission-prompts`, `/focus`, `/goal`, `/heapdump`, `/hooks`, `/loop` (`/proactive`), `/memory`, `/recap`,
+`/sandbox`, `/schedule` (`/routines`), `/scroll-speed`, `/security-review`, `/setup-bedrock`,
+`/stats`, `/stop`, `/team-onboarding`, `/tui`, `/voice`, `/web-setup`
 
 ### Copilot CLI Only (not in Claude Code)
 `/ask` (experimental), `/changelog` (`/release-notes`), `/chronicle` (experimental: `standup|tips|improve|reindex` — session history tools and insights),
@@ -133,6 +143,14 @@ Use this reference when you know a Claude Code command and want the Copilot CLI 
 Note: `/delegate` is the Copilot equivalent of Claude Code's `--remote "task"` flag.
 
 Note: `/on-air` (`/streamer-mode`) has been removed from Copilot CLI.
+
+Note: `/background` (`/bg`) detaches the current session to run as a background agent. No direct Copilot equivalent; closest is Ctrl+X then b to promote to background.
+
+Note: `/goal [condition|clear]` sets a goal so Claude keeps working across turns until the condition is met. No Copilot CLI equivalent.
+
+Note: `/stop` stops the current background session (only available while attached). No Copilot CLI equivalent.
+
+Note: `/scroll-speed` adjusts mouse wheel scroll speed interactively. No Copilot CLI equivalent.
 
 Note: `/theme` options changed to `[default|dim|high-contrast|colorblind]`.
 


### PR DESCRIPTION
Handle new Claude Code CLI additions in the compatibility layer (closes #51):

## Changes

### `cpc` wrapper
- Add handlers for 9 new subcommands (`attach`, `logs`, `respawn`, `rm`, `stop`, `ultrareview`, `project purge`, `setup-token`, `install`) with clear warning messages and suggested alternatives
- Add `--bg` flag to warn list (background agent mode is Claude Code-only; closest: Ctrl+X then b)
- Update help text with new unsupported sections

### `skills/claude-compat/SKILL.md`
- Add new subcommands to CLI Subcommand Mapping table
- Add `--bg` to Unsupported Flags table
- Add `/background`, `/bg`, `/goal`, `/stop`, `/scroll-speed` to Claude Code Only slash commands
- Update `claude agents` description (now opens agent view for background sessions)

### `README.md`
- Add `/background`, `/goal`, `/stop`, `/scroll-speed` to slash command quick reference
- Add 10 new entries to the Limitations section covering `--bg`, background agent management, and related gaps